### PR TITLE
Show API list on homepage

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -3,67 +3,11 @@
   <head>
     <meta charset="UTF-8" />
     <title>API Hub</title>
-    <style>
-      html, body {
-        margin: 0;
-        padding: 0;
-        height: 100%;
-      }
-      #redoc-container,
-      #swagger-ui {
-        height: 100%;
-      }
-      #swagger-ui {
-        display: none;
-      }
-      .navbar {
-        position: fixed;
-        top: 0;
-        width: 100%;
-        background: #f8f8f8;
-        border-bottom: 1px solid #e0e0e0;
-        padding: 10px;
-        z-index: 1000;
-      }
-      .navbar button {
-        margin-right: 10px;
-      }
-      .content {
-        position: absolute;
-        top: 50px;
-        bottom: 0;
-        left: 0;
-        right: 0;
-      }
-    </style>
-    <link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist/swagger-ui.css" />
   </head>
   <body>
-    <div class="navbar">
-      <button onclick="showRedoc()">ReDoc</button>
-      <button onclick="showSwagger()">Swagger UI</button>
-    </div>
-    <div class="content">
-      <div id="redoc-container"></div>
-      <div id="swagger-ui"></div>
-    </div>
-    <script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"></script>
-    <script src="https://unpkg.com/swagger-ui-dist/swagger-ui-bundle.js"></script>
-    <script>
-      const specUrl = './tk-kit/openapi.yaml';
-      function showRedoc() {
-        document.getElementById('redoc-container').style.display = 'block';
-        document.getElementById('swagger-ui').style.display = 'none';
-      }
-      function showSwagger() {
-        document.getElementById('redoc-container').style.display = 'none';
-        document.getElementById('swagger-ui').style.display = 'block';
-        if (!window.swaggerInitialized) {
-          window.swaggerInitialized = true;
-          SwaggerUIBundle({ url: specUrl, dom_id: '#swagger-ui' });
-        }
-      }
-      Redoc.init(specUrl, {}, document.getElementById('redoc-container'));
-    </script>
+    <h1>API Hub</h1>
+    <ul>
+      <li><a href="tk-kit.html">KIT API</a></li>
+    </ul>
   </body>
 </html>

--- a/docs/tk-kit.html
+++ b/docs/tk-kit.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>API Hub</title>
+    <style>
+      html, body {
+        margin: 0;
+        padding: 0;
+        height: 100%;
+      }
+      #redoc-container,
+      #swagger-ui {
+        height: 100%;
+      }
+      #swagger-ui {
+        display: none;
+      }
+      .navbar {
+        position: fixed;
+        top: 0;
+        width: 100%;
+        background: #f8f8f8;
+        border-bottom: 1px solid #e0e0e0;
+        padding: 10px;
+        z-index: 1000;
+      }
+      .navbar button {
+        margin-right: 10px;
+      }
+      .content {
+        position: absolute;
+        top: 50px;
+        bottom: 0;
+        left: 0;
+        right: 0;
+      }
+    </style>
+    <link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist/swagger-ui.css" />
+  </head>
+  <body>
+    <div class="navbar">
+      <button onclick="showRedoc()">ReDoc</button>
+      <button onclick="showSwagger()">Swagger UI</button>
+    </div>
+    <div class="content">
+      <div id="redoc-container"></div>
+      <div id="swagger-ui"></div>
+    </div>
+    <script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"></script>
+    <script src="https://unpkg.com/swagger-ui-dist/swagger-ui-bundle.js"></script>
+    <script>
+      const specUrl = './tk-kit/openapi.yaml';
+      function showRedoc() {
+        document.getElementById('redoc-container').style.display = 'block';
+        document.getElementById('swagger-ui').style.display = 'none';
+      }
+      function showSwagger() {
+        document.getElementById('redoc-container').style.display = 'none';
+        document.getElementById('swagger-ui').style.display = 'block';
+        if (!window.swaggerInitialized) {
+          window.swaggerInitialized = true;
+          SwaggerUIBundle({ url: specUrl, dom_id: '#swagger-ui' });
+        }
+      }
+      Redoc.init(specUrl, {}, document.getElementById('redoc-container'));
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- Display a simple homepage listing available APIs instead of auto-opening tk-kit
- Move tk-kit API documentation to its own page

## Testing
- `python -m py_compile scripts/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68c19c9568b0832080011ec9d0f0bbaf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated TK Kit API explorer with a toggle between Redoc and Swagger UI, rendering from the published OpenAPI spec. Redoc loads by default; Swagger UI initializes on first use. Includes a fixed navbar and full-viewport layout for easier navigation.

* **Documentation**
  * Replaced the previous interactive API docs landing page with a minimal hub that links to the new TK Kit API explorer.
  * Streamlined styling and scripts on the landing page for faster load and simpler navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->