### PR TITLE
feat: organize tk-kit API docs

### DIFF
--- a/docs/tk-kit.html
+++ b/docs/tk-kit.html
@@ -50,7 +50,7 @@
     <script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"></script>
     <script src="https://unpkg.com/swagger-ui-dist/swagger-ui-bundle.js"></script>
     <script>
-      const specUrl = '../tk-kit/openapi.yaml';
+      const specUrl = './tk-kit/openapi.yaml';
       function showRedoc() {
         document.getElementById('redoc-container').style.display = 'block';
         document.getElementById('swagger-ui').style.display = 'none';


### PR DESCRIPTION
## Summary
- group tk-kit endpoints with tags by domain
- fix docs HTML to load OpenAPI spec correctly

## Testing
- `python -m openapi_spec_validator tk-kit/openapi.yaml`
- `npx --yes redoc-cli build tk-kit/openapi.yaml -o /tmp/redoc.html`


------
https://chatgpt.com/codex/tasks/task_e_68c40c1d1e60832085f1afd7d726c022

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Added OpenAPI tags to group endpoints: Orders (Заказы), Transport Routes (Транспортные маршруты), Profiles (Профили), Geography (География), with bilingual descriptions.
  - Applied consistent per-operation tags across relevant endpoints for better navigation and filtering in API docs and client generators.
  - No changes to endpoints, parameters, or response schemas; non‑breaking, metadata-only update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->