### PR TITLE
Copy Dostavista OpenAPI spec in Pages workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -30,6 +30,8 @@ jobs:
         run: |
           mkdir -p docs/tk-kit
           cp tk-kit/openapi.yaml docs/tk-kit/
+          mkdir -p docs/dostavista
+          cp dostavista/openapi.yaml docs/dostavista/
           
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v4


### PR DESCRIPTION
## Summary
- copy Dostavista OpenAPI spec into docs during Pages deployment

## Testing
- `yamllint .github/workflows/pages.yml` *(fails: missing document start, truthy value, bracket spacing, trailing spaces)*

------
https://chatgpt.com/codex/tasks/task_e_68c55e8ad9cc832098364bb3d6c63158

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Published the Dostavista OpenAPI specification alongside the existing TK Kit spec in the docs, making both specs available for reference and download.

* **Chores**
  * Updated the docs deployment workflow to include the Dostavista OpenAPI file in the generated artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->